### PR TITLE
Fix building as a shared library on Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ lib/Makefile.in
 lib/*.lo
 lib/*.o
 lib/*.la
+*.dll*
+*.dylib
+*.exe
 *.tar.gz
 libtool
 m4/
@@ -24,3 +27,6 @@ tests/*.trs
 tests/*_test
 tests/Makefile
 tests/Makefile.in
+
+# editor temp files
+*.sw[nop]

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,9 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign -Wall])
 AM_PROG_AR
 AC_PROG_CXX
-LT_INIT
+LT_INIT([shared win32-dll])
+AC_CANONICAL_HOST
+AS_CASE([$host_os], [*cygwin* | *mingw*], [SIROCCO_LDFLAGS=-no-undefined])
+AC_SUBST(SIROCCO_LDFLAGS)
 AC_CONFIG_FILES([Makefile lib/Makefile tests/Makefile])
 AC_OUTPUT

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,5 +1,5 @@
 lib_LTLIBRARIES = libsirocco.la
 libsirocco_la_SOURCES = icomplex.cpp  interval.cpp $(top_srcdir)/include/list.hpp $(top_srcdir)/include/mp_complex.hpp $(top_srcdir)/include/mp_icomplex.hpp $(top_srcdir)/include/mp_interval.hpp $(top_srcdir)/include/polynomial.hpp $(top_srcdir)/include/sirocco.hpp $(top_srcdir)/include/icomplex.hpp $(top_srcdir)/include/interval.hpp mp_complex.cpp mp_icomplex.cpp mp_interval.cpp polynomial.cpp sirocco.cpp
-libsirocco_la_LDFLAGS = -lm -lmpfr -lgmp
+libsirocco_la_LDFLAGS = $(SIROCCO_LDFLAGS) -lm -lmpfr -lgmp
 AM_CPPFLAGS = -I$(top_srcdir)/include
 include_HEADERS = $(top_srcdir)/include/sirocco.h


### PR DESCRIPTION
This adds some standard tweaks often needed to build shared libraries on Cygwin, as well as MinGW.

In brief, the main purposes of this is to detect the OS, and if so pass the `-no-undefined` option to LDFLAGS.